### PR TITLE
Change CMake install to also install ctest et al.

### DIFF
--- a/vowpal_wabbit/centos7_6_1860-build.Dockerfile
+++ b/vowpal_wabbit/centos7_6_1860-build.Dockerfile
@@ -27,7 +27,7 @@ RUN version=3.13 && build=5 \
    && wget https://cmake.org/files/v$version/cmake-$version.$build-Linux-x86_64.sh \
    && mkdir /opt/cmake \
    && sh cmake-$version.$build-Linux-x86_64.sh --prefix=/opt/cmake --skip-license \
-   && ln -s /opt/cmake/bin/cmake /usr/bin/cmake \
+   && for filename in /opt/cmake/bin/*; do echo Registering $filename; ln -fs $filename /usr/local/bin/`basename $filename`; done \
    && rm -f cmake-$version.$build-Linux-x86_64.sh
 
 # Install gcc-9.2

--- a/vowpal_wabbit/ubuntu1404-build.Dockerfile
+++ b/vowpal_wabbit/ubuntu1404-build.Dockerfile
@@ -54,7 +54,7 @@ RUN version=3.13 && build=5 \
  && wget https://cmake.org/files/v$version/cmake-$version.$build-Linux-x86_64.sh \
  && mkdir /opt/cmake \
  && sh cmake-$version.$build-Linux-x86_64.sh --prefix=/opt/cmake --skip-license \
- && ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake \
+ && for filename in /opt/cmake/bin/*; do echo Registering $filename; ln -fs $filename /usr/local/bin/`basename $filename`; done \
  && rm cmake-$version.$build-Linux-x86_64.sh
 
 # Install Python tools, Miniconda, and setup environment

--- a/vowpal_wabbit/ubuntu1604-build.Dockerfile
+++ b/vowpal_wabbit/ubuntu1604-build.Dockerfile
@@ -38,7 +38,7 @@ RUN version=3.13 && build=5 \
  && wget https://cmake.org/files/v$version/cmake-$version.$build-Linux-x86_64.sh \
  && mkdir /opt/cmake \
  && sh cmake-$version.$build-Linux-x86_64.sh --prefix=/opt/cmake --skip-license \
- && ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake \
+ && for filename in /opt/cmake/bin/*; do echo Registering $filename; ln -fs $filename /usr/local/bin/`basename $filename`; done \
  && rm cmake-$version.$build-Linux-x86_64.sh
 
 # Install Python tools, Miniconda, and setup environment


### PR DESCRIPTION
Our current process installs CMake to /opt/cmake, and makes cmake available to all users by creating a symlink in /usr/bin. It does not create symlinks for other tools (e.g. CPack, CTest), which breaks downstream dev tools which assume all parts of CMake are available.

This change switches to creating symlinks for all parts of the CMake toolkit.