### PR TITLE
Dockerfile for vw binary on alpine image

### DIFF
--- a/.github/workflows/build_deploy_release.yml
+++ b/.github/workflows/build_deploy_release.yml
@@ -20,6 +20,7 @@ jobs:
           username: "${{ secrets.DOCKER_USERNAME }}"
           password: "${{ secrets.DOCKER_PASSWORD }}"
           image_name: "vowpalwabbit/${{matrix.config.image_name}}"
+          image_tag: "${{ github.event.client_payload.tag }}"
           dockerfile: "${{matrix.config.dockerfile}}"
           push_image_and_stages: true
           build_extra_args: "--build-arg branch_or_tag=${{ github.event.client_payload.tag }}"

--- a/.github/workflows/build_deploy_release.yml
+++ b/.github/workflows/build_deploy_release.yml
@@ -22,4 +22,4 @@ jobs:
           image_name: "vowpalwabbit/${{matrix.config.image_name}}"
           dockerfile: "${{matrix.config.dockerfile}}"
           push_image_and_stages: true
-          build_extra_args: "--build-arg branch_or_tag={{ github.event.client_payload.tag }}"
+          build_extra_args: "--build-arg branch_or_tag=${{ github.event.client_payload.tag }}"

--- a/.github/workflows/build_deploy_release.yml
+++ b/.github/workflows/build_deploy_release.yml
@@ -1,0 +1,25 @@
+name: Build and deploy vw image to DockerHub
+
+on:
+  repository_dispatch:
+    types: push-image
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        config:
+        - { image_name: vw-alpine, dockerfile: vowpal_wabbit/vw-alpine.Dockerfile }
+    steps:
+      - uses: actions/checkout@master
+      - name: Login, build and push image
+        if: success()
+        uses: whoan/docker-build-with-cache-action@v3
+        with:
+          username: "${{ secrets.DOCKER_USERNAME }}"
+          password: "${{ secrets.DOCKER_PASSWORD }}"
+          image_name: "vowpalwabbit/${{matrix.config.image_name}}"
+          dockerfile: "${{matrix.config.dockerfile}}"
+          push_image_and_stages: true
+          build_extra_args: "--build-arg branch_or_tag={{ github.event.client_payload.tag }}"

--- a/vowpal_wabbit/vw-alpine.Dockerfile
+++ b/vowpal_wabbit/vw-alpine.Dockerfile
@@ -1,6 +1,6 @@
 FROM vowpalwabbit/ubuntu1604-build AS build
 ARG branch_or_tag
-RUN git clone -b $branch_or_tag --depth=1 https://github.com/VowpalWabbit/vowpal_wabbit.git /vw
+RUN git clone -b $branch_or_tag --depth=1 --recursive https://github.com/VowpalWabbit/vowpal_wabbit.git /vw
 WORKDIR vw
 WORKDIR build
 RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DWARNINGS=Off -DSTATIC_LINK_VW=On -DBUILD_JAVA=Off -DBUILD_PYTHON=Off -DBUILD_TESTS=Off

--- a/vowpal_wabbit/vw-alpine.Dockerfile
+++ b/vowpal_wabbit/vw-alpine.Dockerfile
@@ -1,0 +1,11 @@
+FROM vowpalwabbit/ubuntu1604-build AS build
+ARG branch_or_tag
+RUN git clone -b $branch_or_tag --depth=1 https://github.com/VowpalWabbit/vowpal_wabbit.git /vw
+WORKDIR vw
+WORKDIR build
+RUN cmake .. -DCMAKE_BUILD_TYPE=Release -DWARNINGS=Off -DSTATIC_LINK_VW=On -DBUILD_JAVA=Off -DBUILD_PYTHON=Off -DBUILD_TESTS=Off
+RUN make vw-bin -j $(cat nprocs.txt)
+
+FROM alpine:latest
+COPY --from=build /vw/build/vowpalwabbit/vw .
+ENTRYPOINT ["./vw"]


### PR DESCRIPTION
With this image users with Docker installed can easily use vw without having to build or install dependencies.

After building docker image one can use vw as following:

i.e. to display vw command line arguments:
docker run --rm -ti vw-alpine --help

Alpine does not use glibc so vw features depending on glibc won't work on this image for now (open_socket / network.cc). Everything else should work since it's a static link binary.

Resulting image size is 13.6 MB.