### PR TITLE
Remove Python35 from manylinux image

### DIFF
--- a/vowpal_wabbit/manylinux-2010/build-boost.sh
+++ b/vowpal_wabbit/manylinux-2010/build-boost.sh
@@ -14,7 +14,6 @@ cd $BOOST_ROOT
 
 ./bootstrap.sh --with-libraries=program_options,system,thread,test,chrono,date_time,atomic
 ./b2 -j$(nproc) cxxflags="-fPIC" variant=release link=static install
-./b2 -j$(nproc) cxxflags="-fPIC" variant=release link=static --with-python --user-config="/python-config.jam" python="3.5" install
 ./b2 -j$(nproc) cxxflags="-fPIC" variant=release link=static --with-python --user-config="/python-config.jam" python="3.6" install
 ./b2 -j$(nproc) cxxflags="-fPIC" variant=release link=static --with-python --user-config="/python-config.jam" python="3.7" install
 ./b2 -j$(nproc) cxxflags="-fPIC" variant=release link=static --with-python --user-config="/python-config.jam" python="3.8" install

--- a/vowpal_wabbit/manylinux-2010/python-config.jam
+++ b/vowpal_wabbit/manylinux-2010/python-config.jam
@@ -1,10 +1,4 @@
 using python
-    : "3.5"
-    : "/opt/python/cp35-cp35m"
-    : "/opt/python/cp35-cp35m/include/python3.5m"
-;
-
-using python
     : "3.6"
     : "/opt/python/cp36-cp36m"
     : "/opt/python/cp36-cp36m/include/python3.6m"


### PR DESCRIPTION
Python3.5 causes build failures as it is no longer supported.